### PR TITLE
Add native humidity support to MideaDehumComponent

### DIFF
--- a/components/midea_dehum/midea_dehum.h
+++ b/components/midea_dehum/midea_dehum.h
@@ -32,6 +32,16 @@ class MideaIonSwitch : public switch_::Switch, public Component {
 };
 #endif
 
+class MideaSwingSwitch : public switch_::Switch, public Component {
+ public:
+  void set_parent(class MideaDehumComponent *parent) { this->parent_ = parent; }
+
+ protected:
+  void write_state(bool state) override;
+  class MideaDehumComponent *parent_{nullptr};
+};
+
+
 class MideaDehumComponent : public climate::Climate,
                             public uart::UARTDevice,
                             public Component {
@@ -47,6 +57,10 @@ class MideaDehumComponent : public climate::Climate,
   void set_ion_switch(MideaIonSwitch *s);
   void set_ion_state(bool on);
   bool get_ion_state() const { return this->ion_state_; }
+
+  void set_swing_switch(MideaSwingSwitch *s);
+  void set_swing_state(bool on);
+  bool get_swing_state() const { return this->swing_state_; }
 #endif
 
   std::string display_mode_setpoint_{"Setpoint"};
@@ -99,7 +113,9 @@ class MideaDehumComponent : public climate::Climate,
 
 #ifdef USE_MIDEA_DEHUM_SWITCH
   MideaIonSwitch *ion_switch_{nullptr};
+  MideaSwingSwitch *swing_switch_{nullptr};
   bool ion_state_{false};
+  bool swing_state_{false};
 #endif
   float current_humidity_{NAN};
   float target_humidity_{NAN};

--- a/components/midea_dehum/switch.py
+++ b/components/midea_dehum/switch.py
@@ -7,14 +7,17 @@ from . import midea_dehum_ns, CONF_MIDEA_DEHUM_ID
 cg.add_define("USE_MIDEA_DEHUM_SWITCH")
 
 MideaIonSwitch = midea_dehum_ns.class_("MideaIonSwitch", switch.Switch, cg.Component)
+MideaSwingSwitch = midea_dehum_ns.class_("MideaSwingSwitch", switch.Switch, cg.Component)
 MideaDehum = midea_dehum_ns.class_("MideaDehumComponent", cg.Component)
 
 CONF_IONIZER = "ionizer"
+CONF_SWING = "swing"
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(CONF_ID): cv.declare_id(MideaIonSwitch),
     cv.Required(CONF_MIDEA_DEHUM_ID): cv.use_id(MideaDehum),
-    cv.Required(CONF_IONIZER): switch.switch_schema(MideaIonSwitch, icon="mdi:air-purifier"),
+    cv.Optional(CONF_IONIZER): switch.switch_schema(MideaIonSwitch, icon="mdi:air-purifier"),
+    cv.Optional(CONF_SWING): switch.switch_schema(MideaSwingSwitch, icon="mdi:format-vertical-align-center"), 
 })
 
 async def to_code(config):
@@ -23,3 +26,7 @@ async def to_code(config):
     if CONF_IONIZER in config:
         sw = await switch.new_switch(config[CONF_IONIZER])
         cg.add(parent.set_ion_switch(sw))
+        
+    if CONF_SWING in config:
+        sw = await switch.new_switch(config[CONF_SWING])
+        cg.add(parent.set_swing_switch(sw))


### PR DESCRIPTION
Replaces temperature-based control with proper humidity handling.
Home Assistant now shows and controls relative humidity (%) instead of temperature (°C).

**Changes**

Added target_humidity / current_humidity support
Updated ClimateTraits and control() accordingly
Adjusted publishState() to report humidity values
Improved Home Assistant UI consistency for dehumidifiers

Tested

✅ Comfee (CDDF7-16DEN7-WFI) dehumidifier (ESP8266) – humidity control works correctly

<img width="704" height="734" alt="image" src="https://github.com/user-attachments/assets/5a4894f8-e906-44bc-92f7-eed3e8f052b7" />
<img width="705" height="709" alt="image" src="https://github.com/user-attachments/assets/ad448f55-e740-41d0-b18e-a08c84f45638" />
