### PR TITLE
Timer + internal improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
   <img src="https://github.com/Hypfer/esp8266-midea-dehumidifier/blob/master/img/logo.svg" width="800" alt="esp8266-midea-dehumidifier">
   <h2>Free your dehumidifier from the cloud — now with ESPHome</h2>
 </div>
+# Update 21/10/2025, in this release:
+
+* 🆕 Added internal device timer support (optional)
+
+* 🤝 Improved handshake reliability
+
+* ⚙️ General background and stability improvements
+
 
 This project is an **ESPHome-based port** of [Hypfer’s esp8266-midea-dehumidifier](https://github.com/Hypfer/esp8266-midea-dehumidifier).  
 While the original version used a custom MQTT firmware, this one is a **native ESPHome component**, providing full **Home Assistant integration** without MQTT or cloud dependencies.
@@ -27,6 +35,7 @@ Supported entities:
 | **Error Sensor (optional)** | Reports current error code (optional in YAML) |
 | **ION Switch (optional)** | Controls ionizer state if supported |
 | **Swing Switch (optional)** | Controls swing if supported |
+| **Timer Number (optional)** | Controls the internal device timer if supported |
 
 Optional entities can be included or excluded simply by adding or omitting them from your YAML.
 
@@ -157,16 +166,20 @@ switch:
 # 🆕 Optional swing control (if supported)
     swing:
       name: "Swing"
+
+# Optional timer number entity for the internal device timer
+# When device off -> timer to turn on
+# When device on -> timer to turn off
+# Toggling the device on/off resets the timer
+# 0.5h increments, max: 24h
+number:
+  - platform: midea_dehum
+    midea_dehum_id: midea_dehum_comp
+    timer:
+      name: "Internal Device Timer"
+
 ```
 All entities appear automatically in Home Assistant with native ESPHome support.
-
-✅ Highlights:
-
-Rename the visible mode labels freely.
-
-Does not affect communication or function.
-
-If omitted, defaults (Setpoint, Continuous, Smart, ClothesDrying) are used automatically.
 
 🧩 Component Architecture
 
@@ -175,7 +188,8 @@ midea_dehum.cpp/h	Core UART communication and protocol handling
 climate.py	Main control entity (mode, fan, humidity, etc.)
 binary_sensor.py	“Bucket full” status
 sensor.py	Optional error code reporting
-switch.py	Optional ionizer control
+switch.py	Optional switches
+number.py Optional timer entity
 
 🧪 Supported Features
 
@@ -196,6 +210,8 @@ Bucket full status
 Error code reporting (optional)
 
 Ionizer toggle (if supported)
+
+On/Off timer (if supported)
 
 Note: The Temperature-Humidity values from device aren't reliable, better not use them for automations.
 

--- a/components/midea_dehum/__init__.py
+++ b/components/midea_dehum/__init__.py
@@ -38,3 +38,5 @@ async def to_code(config):
     cg.add(var.set_display_mode_continuous(config["display_mode_continuous"]))
     cg.add(var.set_display_mode_smart(config["display_mode_smart"]))
     cg.add(var.set_display_mode_clothes_drying(config["display_mode_clothes_drying"]))
+
+

--- a/components/midea_dehum/component.yaml
+++ b/components/midea_dehum/component.yaml
@@ -5,3 +5,4 @@ files:
 optional:
   - sensor.py
   - switch.py
+  - select.py

--- a/components/midea_dehum/midea_dehum.cpp
+++ b/components/midea_dehum/midea_dehum.cpp
@@ -3,28 +3,24 @@
 #include "esphome/core/application.h"
 #include "esphome/core/preferences.h"
 #include <cmath>
-#ifdef USE_MIDEA_DEHUM_SENSOR
-#include "esphome/components/sensor/sensor.h"
-#endif
-#ifdef USE_MIDEA_DEHUM_BINARY_SENSOR
-#include "esphome/components/binary_sensor/binary_sensor.h"
-#endif
-#ifdef USE_MIDEA_DEHUM_SWITCH
-#include "esphome/components/switch/switch.h"
-#endif
 
 namespace esphome {
 namespace midea_dehum {
 
 static const char *const TAG = "midea_dehum";
 
-static uint8_t networkStatus[20];
+static uint8_t networkStatus[19];
 static uint8_t currentHeader[10];
 static uint8_t getStatusCommand[21] = {
   0x41, 0x81, 0x00, 0xff, 0x03, 0xff,
   0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x03
+};
+
+static uint8_t dongleAnnounce[12] = {
+  0xAA, 0x0B, 0xFF, 0xF4, 0x00, 0x00,
+  0x01, 0x00, 0x00, 0x07, 0x00, 0xFA
 };
 
 static uint8_t setStatusCommand[25];
@@ -77,12 +73,14 @@ struct dehumidifierState_t {
 };
 static dehumidifierState_t state = {false, 3, 60, 50, 0, 0, 0};
 
+// CRC8 check (second-to-last TX byte)
 static uint8_t crc8(uint8_t *addr, uint8_t len) {
   uint8_t crc = 0;
   while (len--) crc = crc_table[*addr++ ^ crc];
   return crc;
 }
 
+// Calculate the sum (last TX byte)
 static uint8_t checksum(uint8_t *addr, uint8_t len) {
   uint8_t sum = 0;
   addr++;  // skip 0xAA
@@ -90,78 +88,138 @@ static uint8_t checksum(uint8_t *addr, uint8_t len) {
   return 256 - sum;
 }
 
+// Device error sensor
 #ifdef USE_MIDEA_DEHUM_ERROR
 void MideaDehumComponent::set_error_sensor(sensor::Sensor *s) {
   this->error_sensor_ = s;
 }
 #endif
 
+// Bucket full sensor
 #ifdef USE_MIDEA_DEHUM_BUCKET
 void MideaDehumComponent::set_bucket_full_sensor(binary_sensor::BinarySensor *s) { this->bucket_full_sensor_ = s; }
 #endif
 
+// Device IONizer
 #ifdef USE_MIDEA_DEHUM_ION
-void MideaDehumComponent::set_ion_state(bool on) {
-  if (this->ion_state_ == on) return;
+void MideaDehumComponent::set_ion_state(bool on, bool from_device) {
+  if (this->ion_state_ == on && !from_device) return;
   this->ion_state_ = on;
-  ESP_LOGI(TAG, "Ionizer %s", on ? "ON" : "OFF");
-  this->sendSetStatus();
+
+  if (!from_device) {
+    this->sendSetStatus();
+  }
+
+  if (this->ion_switch_) {
+    this->ion_switch_->publish_state(this->ion_state_);
+  }
 }
+
 void MideaDehumComponent::set_ion_switch(MideaIonSwitch *s) {
   this->ion_switch_ = s;
-  if (s) s->set_parent(this);
+  if (s) {
+    s->set_parent(this);
+    s->publish_state(this->ion_state_);
+  }
 }
 
 void MideaIonSwitch::write_state(bool state) {
   if (!this->parent_) return;
-  this->parent_->set_ion_state(state);
+  this->parent_->set_ion_state(state, false);
 }
 #endif
+
+// Air Swing
 #ifdef USE_MIDEA_DEHUM_SWING
-void MideaDehumComponent::set_swing_state(bool on) {
-  if (this->swing_state_ == on) return;
+void MideaDehumComponent::set_swing_state(bool on, bool from_device) {
+  if (this->swing_state_ == on && !from_device) return;
+
   this->swing_state_ = on;
-  ESP_LOGI(TAG, "Swing %s", on ? "ON" : "OFF");
-  this->sendSetStatus();
+
+  if (!from_device) {
+    this->sendSetStatus();
+  }
+
+  if (this->swing_switch_) {
+    this->swing_switch_->publish_state(this->swing_state_);
+  }
 }
 
 void MideaDehumComponent::set_swing_switch(MideaSwingSwitch *s) {
   this->swing_switch_ = s;
-  if (s) s->set_parent(this);
+  if (s) {
+    s->set_parent(this);
+    s->publish_state(this->swing_state_);
+  }
 }
 
 void MideaSwingSwitch::write_state(bool state) {
   if (!this->parent_) return;
-  this->parent_->set_swing_state(state);
+  this->parent_->set_swing_state(state, false);
 }
 #endif
-#ifdef USE_MIDEA_DEHUM_BEEP
 
-void MideaDehumComponent::set_beep_switch(MideaBeepSwitch *s) {
-  this->beep_switch_ = s;
-  if (s) s->set_parent(this);                     // << CRUCIAL
-  if (this->beep_switch_)
-    this->beep_switch_->publish_state(this->beep_state_);
+// Defrost pump
+#ifdef USE_MIDEA_DEHUM_PUMP
+void MideaDehumComponent::set_pump_switch(MideaPumpSwitch *s) {
+  this->pump_switch_ = s;
+  if (s) s->set_parent(this);
+  if (this->pump_switch_) {
+    this->pump_switch_->publish_state(this->pump_state_);
+  }
 }
 
+void MideaDehumComponent::set_pump_state(bool on, bool from_device) {
+  if (this->pump_state_ == on && !from_device)
+    return;
+
+  this->pump_state_ = on;
+
+  if (!from_device) {
+    this->sendSetStatus();
+  }
+
+  if (this->pump_switch_) {
+    this->pump_switch_->publish_state(this->pump_state_);
+  }
+
+  ESP_LOGI(TAG, "Pump %s (from %s)",
+           on ? "ON" : "OFF",
+           from_device ? "device" : "user");
+}
+
+void MideaPumpSwitch::write_state(bool state) {
+  if (!this->parent_) return;
+  // Mark as user-initiated toggle
+  this->parent_->set_pump_state(state, false);
+}
+#endif
+
+// Toggle Device Buzzer on commands
+#ifdef USE_MIDEA_DEHUM_BEEP
 void MideaDehumComponent::set_beep_state(bool on) {
+  // Only send if the user requested a change (not just a redundant write)
   bool was = this->beep_state_;
+  if (was == on) {
+    ESP_LOGD(TAG, "Beep state unchanged (%s)", on ? "ON" : "OFF");
+    return;
+  }
+
   this->beep_state_ = on;
 
-  ESP_LOGI(TAG, "Beeper request: %s (was %s)",
-           on ? "ON" : "OFF", was ? "ON" : "OFF");
-
-  // Persist
+  // Persist the new state
   auto pref = global_preferences->make_preference<bool>(0xBEE1234);
-  bool saved = this->beep_state_;
-  pref.save(&saved);
+  pref.save(&this->beep_state_);
 
-  // Apply immediately (ALWAYS send, even if 'on' didn't change)
+  // Immediately apply it to the hardware
   this->sendSetStatus();
 
   // Keep HA in sync
-  if (this->beep_switch_)
+  if (this->beep_switch_) {
     this->beep_switch_->publish_state(this->beep_state_);
+  }
+
+  ESP_LOGI(TAG, "Beep state changed -> %s", on ? "ON" : "OFF");
 }
 
 void MideaDehumComponent::restore_beep_state() {
@@ -174,49 +232,147 @@ void MideaDehumComponent::restore_beep_state() {
     this->beep_state_ = false;
     ESP_LOGI(TAG, "No saved Beeper state found. Defaulting to OFF.");
   }
-  if (this->beep_switch_) this->beep_switch_->publish_state(this->beep_state_);
+
+  // Immediately sync the restored state to HA
+  if (this->beep_switch_) {
+    this->beep_switch_->publish_state(this->beep_state_);
+  }
+}
+
+void MideaDehumComponent::set_beep_switch(MideaBeepSwitch *s) {
+  this->beep_switch_ = s;
+  if (s) {
+    s->set_parent(this);
+    s->publish_state(this->beep_state_);  // ensures HA starts with correct state
+  }
 }
 
 void MideaBeepSwitch::write_state(bool state) {
-  ESP_LOGI("midea_dehum", "Beep switch write_state(%s)", state ? "ON" : "OFF");
   if (!this->parent_) return;
+
+  ESP_LOGI(TAG, "Beep switch toggled from HA -> %s", state ? "ON" : "OFF");
   this->parent_->set_beep_state(state);
-  this->publish_state(state);
+  // publish_state() happens in parent after setting, so not needed here
 }
 #endif
 
+// Set Sleep Switch on device 
 #ifdef USE_MIDEA_DEHUM_SLEEP
 void MideaDehumComponent::set_sleep_switch(MideaSleepSwitch *s) {
   this->sleep_switch_ = s;
   if (s) s->set_parent(this);
-  if (this->sleep_switch_)
+  if (this->sleep_switch_) {
     this->sleep_switch_->publish_state(this->sleep_state_);
-}
-
-void MideaDehumComponent::set_sleep_state(bool on) {
-  this->sleep_state_ = on;
-  auto pref = global_preferences->make_preference<bool>(0x5E33123);
-  pref.save(&this->sleep_state_);
-  this->sendSetStatus();
-  if (this->sleep_switch_) this->sleep_switch_->publish_state(this->sleep_state_);
-}
-
-void MideaDehumComponent::restore_sleep_state() {
-  auto pref = global_preferences->make_preference<bool>(0x5E33123);
-  bool saved = false;
-  if (pref.load(&saved)) {
-    this->sleep_state_ = saved;
-    ESP_LOGI(TAG, "Restored sleep mode: %s", saved ? "ON" : "OFF");
-  } else {
-    this->sleep_state_ = false;
   }
-  if (this->sleep_switch_) this->sleep_switch_->publish_state(this->sleep_state_);
+}
+
+void MideaDehumComponent::set_sleep_state(bool on, bool from_device) {
+  if (this->sleep_state_ == on && !from_device) return;
+
+  this->sleep_state_ = on;
+
+  if (!from_device) {
+    this->sendSetStatus();
+  }
+
+  if (this->sleep_switch_) {
+    this->sleep_switch_->publish_state(this->sleep_state_);
+  }
+
+  ESP_LOGI(TAG, "Sleep mode %s (from %s)",
+           on ? "ON" : "OFF",
+           from_device ? "device" : "user");
 }
 
 void MideaSleepSwitch::write_state(bool state) {
   if (!this->parent_) return;
-  this->parent_->set_sleep_state(state);
-  this->publish_state(state);
+  // Mark as user-initiated
+  this->parent_->set_sleep_state(state, false);
+}
+#endif
+
+// Get the device capabilities (BETA)
+#ifdef USE_MIDEA_DEHUM_CAPABILITIES
+void MideaDehumComponent::update_capabilities_select(const std::vector<std::string> &options) {
+  if (this->capabilities_select_) {
+    this->capabilities_select_->traits.set_options(options);
+    this->capabilities_select_->publish_state(options.empty() ? "" : options.front());
+    ESP_LOGI(TAG, "Updated capabilities select with %d options", (int)options.size());
+  }
+}
+
+// Query device capabilities (B5 command)
+void MideaDehumComponent::getDeviceCapabilities() {
+  uint8_t payload[] = {
+    0xB5,  // Command ID
+    0x01,  // Sub-command
+    0x00,  // Reserved
+    0x00   // Reserved
+  };
+
+  this->sendMessage(0x03, 0x03, 0x00, sizeof(payload), payload);
+}
+
+// Query additional device capabilities (B5 extended command)
+void MideaDehumComponent::getDeviceCapabilitiesMore() {
+  uint8_t payload[] = {
+    0xB5,  // Command ID
+    0x01,  // Sub-command
+    0x01,  // Extended request
+    0x00,
+    0x00
+  };
+
+  this->sendMessage(0x03, 0x03, 0x00, sizeof(payload), payload);
+}
+#endif
+
+// Device internal Timer
+#ifdef USE_MIDEA_DEHUM_TIMER
+void MideaDehumComponent::set_timer_number(MideaTimerNumber *n) {
+  this->timer_number_ = n;
+  if (n) {
+    n->set_parent(this);
+    n->publish_state(this->last_timer_hours_);
+  }
+}
+
+void MideaDehumComponent::set_timer_hours(float hours, bool from_device) {
+  hours = std::clamp(hours, 0.0f, 24.0f);
+  this->last_timer_hours_ = hours;
+
+  if (!from_device) {
+    // User-initiated → mark pending
+    this->timer_write_pending_ = true;
+    this->pending_timer_hours_ = hours;
+    this->pending_applies_to_on_ = !state.powerOn;
+
+    ESP_LOGI("midea_dehum_timer",
+             "User-set timer pending -> %.2f h (applies to %s timer)",
+             hours, this->pending_applies_to_on_ ? "ON" : "OFF");
+
+    if (this->timer_number_) {
+      float current = this->timer_number_->state;
+      if (fabs(current - hours) > 0.01f)
+        this->timer_number_->publish_state(hours);
+    }
+
+    // Send new value to device
+    this->sendSetStatus();
+  } else {
+    // Update from device → only if it actually changed
+    if (this->timer_number_) {
+      float current = this->timer_number_->state;
+      if (fabs(current - hours) > 0.01f)
+        this->timer_number_->publish_state(hours);
+    }
+  }
+}
+
+void MideaTimerNumber::control(float value) {
+  if (!this->parent_) return;
+  ESP_LOGI("midea_dehum_timer", "Timer number changed from HA -> %.2f h", value);
+  this->parent_->set_timer_hours(value, false);
 }
 #endif
 
@@ -230,21 +386,23 @@ void MideaDehumComponent::setup() {
 #ifdef USE_MIDEA_DEHUM_BEEP
   this->restore_beep_state();
 #endif
-#ifdef USE_MIDEA_DEHUM_SLEEP
-  this->restore_sleep_state();
-#endif
-  App.scheduler.set_timeout(this, "initial_network", 3000, [this]() {
-    this->updateAndSendNetworkStatus();
+
+  this->handshake_step_ = 0;
+  this->handshake_done_ = false;
+
+  App.scheduler.set_timeout(this, "start_handshake", 2000, [this]() {
+    this->performHandshakeStep();
   });
 
-  App.scheduler.set_timeout(this, "init_get_status", 5000, [this]() {
-    this->getStatus();
-  });
 }
 
 void MideaDehumComponent::loop() {
   this->handleUart();
-
+  
+  if (!this->handshake_done_) {
+    return;
+  }
+  
   static uint32_t last_status_poll = 0;
   const uint32_t status_poll_interval = 3000;
   uint32_t now = millis();
@@ -252,6 +410,410 @@ void MideaDehumComponent::loop() {
     last_status_poll = now;
     this->getStatus();
   }
+}
+
+void MideaDehumComponent::clearRxBuf() { memset(serialRxBuf, 0, sizeof(serialRxBuf)); }
+void MideaDehumComponent::clearTxBuf() { memset(serialTxBuf, 0, sizeof(serialTxBuf)); }
+
+// Handle incoming RX packets
+void MideaDehumComponent::handleUart() {
+  if (!this->uart_) return;
+
+  static size_t rx_len = 0;
+
+  while (this->uart_->available()) {
+    uint8_t byte_in;
+    if (!this->uart_->read_byte(&byte_in)) break;
+
+    last_rx_time_ = millis();
+    bus_state_ = BUS_RECEIVING;
+
+    if (rx_len < sizeof(serialRxBuf)) {
+      serialRxBuf[rx_len++] = byte_in;
+    } else {
+      rx_len = 0;
+      bus_state_ = BUS_IDLE;
+      continue;
+    }
+
+    // Validate start byte
+    if (rx_len == 1 && serialRxBuf[0] != 0xAA) {
+      rx_len = 0;
+      continue;
+    }
+
+    // Once length known, check if frame complete
+    if (rx_len >= 2) {
+      const uint8_t expected_len = serialRxBuf[1];
+      if (expected_len < 3 || expected_len > sizeof(serialRxBuf)) {
+        rx_len = 0;
+        bus_state_ = BUS_IDLE;
+        continue;
+      }
+
+      if (rx_len >= expected_len) {
+        bus_state_ = BUS_IDLE;
+
+        std::vector<uint8_t> local_data(serialRxBuf, serialRxBuf + rx_len);
+        this->processPacket(local_data.data(), local_data.size());
+
+        rx_len = 0;
+      }
+    }
+  }
+
+  // Timeout if RX stalled
+  if (bus_state_ == BUS_RECEIVING && millis() - last_rx_time_ > 50) {
+    rx_len = 0;
+    bus_state_ = BUS_IDLE;
+  }
+
+  // Send queued TX once bus idle
+  if (bus_state_ == BUS_IDLE && tx_pending_) {
+    this->sendQueuedPacket();
+  }
+}
+
+// Write the HEADER for all TX packets
+void MideaDehumComponent::writeHeader(uint8_t msgType, uint8_t agreementVersion, uint8_t frameSyncCheck, uint8_t packetLength) {
+  currentHeader[0] = 0xAA;
+  currentHeader[1] = 10 + packetLength + 1;
+  currentHeader[2] = this->device_info_known_ ? this->appliance_type_ : 0xFF;
+  currentHeader[3] = frameSyncCheck;
+  currentHeader[4] = 0x00;
+  currentHeader[5] = 0x00;
+  currentHeader[6] = 0x00;
+  currentHeader[7] = this->device_info_known_ ? this->protocol_version_ : 0x00;
+  currentHeader[8] = agreementVersion;
+  currentHeader[9] = msgType;
+}
+
+// If there is BUS activity queue the TX packets
+void MideaDehumComponent::queueTx(const uint8_t *data, size_t len) {
+  if (bus_state_ == BUS_IDLE) {
+    this->write_array(data, len);
+    bus_state_ = BUS_SENDING;
+    App.scheduler.set_timeout(this, "bus_idle_guard", 20, [this]() {
+      bus_state_ = BUS_IDLE;
+    });
+  } else {
+    tx_buffer_.assign(data, data + len);
+    tx_pending_ = true;
+  }
+}
+
+// Send queued TX packets
+void MideaDehumComponent::sendQueuedPacket() {
+  if (!tx_pending_) return;
+  this->write_array(tx_buffer_.data(), tx_buffer_.size());
+  tx_pending_ = false;
+  bus_state_ = BUS_SENDING;
+  App.scheduler.set_timeout(this, "bus_idle_guard", 20, [this]() {
+    bus_state_ = BUS_IDLE;
+  });
+}
+
+// Initial Handshakes between Dongle and Device
+void MideaDehumComponent::performHandshakeStep() {
+  switch (this->handshake_step_) {
+    case 0: {
+      this->write_array(dongleAnnounce, sizeof(dongleAnnounce));
+      this->handshake_step_ = 1;
+      break;
+    }
+
+    case 1: {
+      uint8_t payloadLength = 19;
+      uint8_t payload[19];
+      memset(payload, 0, sizeof(payload));
+      
+      this->sendMessage(0xA0, 0x08, 0xBF, payloadLength, payload);
+      
+      this->handshake_step_ = 2;
+      break;
+    }
+
+    case 2: {
+      this->updateAndSendNetworkStatus(true);
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
+// Process of the RX Packet received
+void MideaDehumComponent::processPacket(uint8_t *data, size_t len) {
+  // Pretty print packet
+  std::string hex_str;
+  hex_str.reserve(len * 3);
+  for (size_t i = 0; i < len; i++) {
+    char buf[4];
+    snprintf(buf, sizeof(buf), "%02X ", data[i]);
+    hex_str += buf;
+  }
+  ESP_LOGI(TAG, "RX packet (%u bytes): %s", (unsigned)len, hex_str.c_str());
+
+  // Device ACK response
+  if (data[9] == 0x07 && this->handshake_step_ == 1) {
+    this->appliance_type_ = data[2];
+    this->protocol_version_ = data[7];
+    this->device_info_known_ = true;
+    App.scheduler.set_timeout(this, "handshake_step_1", 200, [this]() {
+      this->performHandshakeStep();
+      this->clearRxBuf();
+    });
+  }
+  // Requested Dongle network status
+  else if (data[9] == 0xA0 && this->handshake_step_ == 2) {
+    App.scheduler.set_timeout(this, "handshake_step_2", 200, [this]() {
+      this->performHandshakeStep();
+      this->clearRxBuf();
+    });
+  }
+  // Requested UART ping
+  else if (data[9] == 0x05 && !this->handshake_done_) {
+    this->queueTx(data, data[1] + 1);
+    this->handshake_done_ = true;
+#ifdef USE_MIDEA_DEHUM_CAPABILITIES
+    static bool capabilities_requested = false;
+    if (!capabilities_requested) {
+      capabilities_requested = true;
+      App.scheduler.set_timeout(this, "get_capabilities_after_handshakes", 3000, [this]() {
+        this->getDeviceCapabilities();
+      });
+    }
+#endif
+    App.scheduler.set_timeout(this, "post_handshake_init", 1500, [this]() {
+      this->getStatus();
+    });
+  }
+  // State response
+  else if (data[10] == 0xC8) {
+    this->parseState();
+    this->publishState();
+    if(!this->handshake_done_){
+      this->handshake_done_ = true;
+#ifdef USE_MIDEA_DEHUM_CAPABILITIES
+      static bool capabilities_requested = false;
+      if (!capabilities_requested) {
+        capabilities_requested = true;
+        App.scheduler.set_timeout(this, "post_handshake_init", 3000, [this]() {
+          this->getDeviceCapabilities();
+        });
+      }
+#endif
+    }
+  }
+  // Capabilities response
+  else if (data[10] == 0xB5) {
+    std::string dump;
+    for (size_t i = 0; i < len; i++) {
+      char b[4];
+      snprintf(b, sizeof(b), "%02X ", data[i]);
+      dump += b;
+    }
+    ESP_LOGI(TAG, "RX <- DeviceCapabilities (B5): %s", dump.c_str());
+
+#ifdef USE_MIDEA_DEHUM_CAPABILITIES
+    std::vector<std::string> caps;
+
+    // Capabilities mapping
+    if (data[14] & 0x01) caps.push_back("Power Button");
+    if (data[14] & 0x02) caps.push_back("Timer");
+    if (data[14] & 0x04) caps.push_back("Child Lock");
+    if (data[14] & 0x08) caps.push_back("Swing");
+    if (data[14] & 0x10) caps.push_back("Display");
+    if (data[14] & 0x20) caps.push_back("Sleep Mode");
+    if (data[14] & 0x40) caps.push_back("Ionizer");
+    if (data[14] & 0x80) caps.push_back("Pump");
+
+    if (data[15] & 0x01) caps.push_back("Beep Control");
+    if (data[15] & 0x02) caps.push_back("Humidity Sensor");
+    if (data[15] & 0x04) caps.push_back("Temperature Sensor");
+    if (data[15] & 0x08) caps.push_back("Fan Speed Control");
+    if (data[15] & 0x10) caps.push_back("Heater");
+    if (data[15] & 0x20) caps.push_back("Water Level Sensor");
+    if (data[15] & 0x40) caps.push_back("Compressor Delay");
+    if (data[15] & 0x80) caps.push_back("Tank Sensor");
+
+    if (data[16] & 0x01) caps.push_back("Filter Indicator");
+    if (data[16] & 0x02) caps.push_back("Smart Dry Mode");
+    if (data[16] & 0x04) caps.push_back("Continuous Mode");
+    if (data[16] & 0x08) caps.push_back("Clothes Drying Mode");
+    if (data[16] & 0x10) caps.push_back("Air Quality Sensor");
+    if (data[16] & 0x20) caps.push_back("WiFi Module");
+    if (data[16] & 0x40) caps.push_back("Display Brightness");
+    if (data[16] & 0x80) caps.push_back("Filter Reminder");
+
+    if (data[17] & 0x01) caps.push_back("Defrost");
+    if (data[17] & 0x02) caps.push_back("Tank Full Sensor");
+    if (data[17] & 0x04) caps.push_back("Heater Temperature");
+    if (data[17] & 0x08) caps.push_back("Air Circulation Mode");
+    if (data[17] & 0x10) caps.push_back("Humidity Presets");
+    if (data[17] & 0x20) caps.push_back("Power Recovery");
+    if (data[17] & 0x40) caps.push_back("Self Clean");
+    if (data[17] & 0x80) caps.push_back("Compressor Heater");
+
+    if (data[18] & 0x01) caps.push_back("Error Codes");
+    if (data[18] & 0x02) caps.push_back("Firmware Version");
+    if (data[18] & 0x04) caps.push_back("EEPROM Control");
+    if (data[18] & 0x08) caps.push_back("Swing Horizontal");
+    if (data[18] & 0x10) caps.push_back("Swing Vertical");
+    if (data[18] & 0x20) caps.push_back("Overheat Protection");
+    if (data[18] & 0x40) caps.push_back("Overcurrent Protection");
+    if (data[18] & 0x80) caps.push_back("Voltage Monitoring");
+
+    if (caps.empty()) caps.push_back("Unknown / No response");
+    this->update_capabilities_select(caps);
+    ESP_LOGI(TAG, "Detected %d capability flags", (int)caps.size());
+    this->clearRxBuf();
+#endif
+  }
+  // Network Status request
+  else if (data[10] == 0x63) {
+    this->updateAndSendNetworkStatus(true);
+    this->clearRxBuf();
+  }
+  // Reset WIFI request
+  else if (
+    data[0] == 0xAA &&
+    data[9] == 0x64 &&
+    data[11] == 0x01 &&
+    data[15] == 0x01
+  ) {
+    this->clearRxBuf();
+    App.scheduler.set_timeout(this, "factory_reset", 500, [this]() {
+      ESP_LOGW(TAG, "Performing factory reset...");
+      global_preferences->reset();
+
+      App.scheduler.set_timeout(this, "reboot_after_reset", 300, []() {
+        App.safe_reboot();
+      });
+    });
+  }
+}
+// Get the status sent from device
+void MideaDehumComponent::parseState() {
+  // --- Basic operating parameters ---
+  state.powerOn          = (serialRxBuf[11] & 0x01) != 0;
+  state.mode              = serialRxBuf[12] & 0x0F;
+  state.fanSpeed          = serialRxBuf[13] & 0x7F;
+  state.humiditySetpoint  = (serialRxBuf[17] > 100) ? 99 : serialRxBuf[17];
+
+#ifdef USE_MIDEA_DEHUM_TIMER
+  // --- Parse timer fields from payload bytes 14..16 ---
+  const uint8_t on_raw  = serialRxBuf[14];
+  const uint8_t off_raw = serialRxBuf[15];
+  const uint8_t ext_raw = serialRxBuf[16];
+
+  const bool on_timer_set  = (on_raw  & 0x80) != 0;
+  const bool off_timer_set = (off_raw & 0x80) != 0;
+
+  uint8_t on_hr = 0, off_hr = 0;
+  int on_min = 0, off_min = 0;
+
+  if (on_timer_set) {
+    on_hr  = (on_raw & 0x7C) >> 2;
+    on_min = ((on_raw & 0x03) + 1) * 15 - ((ext_raw & 0xF0) >> 4);
+    if (on_min < 0) on_min += 60;
+  }
+
+  if (off_timer_set) {
+    off_hr  = (off_raw & 0x7C) >> 2;
+    off_min = ((off_raw & 0x03) + 1) * 15 - (ext_raw & 0x0F);
+    if (off_min < 0) off_min += 60;
+  }
+
+  const float on_timer_hours  = on_timer_set  ? (on_hr  + (on_min  / 60.0f)) : 0.0f;
+  const float off_timer_hours = off_timer_set ? (off_hr + (off_min / 60.0f)) : 0.0f;
+
+  if (on_timer_set)
+    ESP_LOGI("midea_dehum_timer", "Parsed ON timer: %.2f h (h=%u, min=%u)", on_timer_hours, on_hr, on_min);
+  if (off_timer_set)
+    ESP_LOGI("midea_dehum_timer", "Parsed OFF timer: %.2f h (h=%u, min=%u)", off_timer_hours, off_hr, off_min);
+
+  // Cache raw bytes
+  this->last_on_raw_  = on_raw;
+  this->last_off_raw_ = off_raw;
+  this->last_ext_raw_ = ext_raw;
+
+  // Update HA entity with the *active* timer
+  float timer_hours = 0.0f;
+  if (!state.powerOn && on_timer_set) {
+    timer_hours = on_timer_hours;
+  } else if (state.powerOn && off_timer_set) {
+    timer_hours = off_timer_hours;
+  }
+
+  if (this->timer_number_) {
+    this->set_timer_hours(timer_hours, true);  // from_device=true: no resend
+  }
+#endif
+// --- BYTE19 Related features ---
+  
+  // --- Panel light / brightness class (bits 7–6) ---
+#ifdef USE_MIDEA_DEHUM_LIGHT
+  uint8_t new_light_class = (serialRxBuf[19] & 0xC0) >> 6;
+  if (new_light_class != this->light_class_) {
+    this->light_class_ = new_light_class;
+    if (this->light_select_) {
+      const char* light_str =
+        new_light_class == 0 ? "Auto" :
+        new_light_class == 1 ? "Off" :
+        new_light_class == 2 ? "Low" : "High";
+      this->light_select_->publish_state(light_str);
+    }
+  }
+#endif
+
+  // --- Ionizer (bit 6) ---
+#ifdef USE_MIDEA_DEHUM_ION
+  bool new_ion_state = (serialRxBuf[19] & 0x40) != 0;
+  if (new_ion_state != this->ion_state_) {
+    this->set_ion_state(new_ion_state, true);
+  }
+#endif
+
+  // --- Sleep mode (bit 5) ---
+#ifdef USE_MIDEA_DEHUM_SLEEP
+  bool new_sleep_state = (serialRxBuf[19] & 0x20) != 0;
+  if (new_sleep_state != this->sleep_state_) {
+    this->set_sleep_state(new_sleep_state, true);
+  }
+#endif
+
+  // --- Optional: Pump bits (3–4) ---
+#ifdef USE_MIDEA_DEHUM_PUMP
+  bool new_pump_state = (serialRxBuf[19] & 0x08) != 0;
+  if (new_pump_state != this->pump_state_) {
+    this->set_pump_state(new_pump_state, true);
+  }
+#endif
+
+  // --- Vertical swing (byte 20, bit 5) ---
+#ifdef USE_MIDEA_DEHUM_SWING
+  bool new_swing_state = (serialRxBuf[20] & 0x20) != 0;
+  if (new_swing_state != this->swing_state_) {
+    this->set_swing_state(new_swing_state, true);
+  }
+#endif
+
+  // --- Environmental readings ---
+  state.currentHumidity = serialRxBuf[26];
+  state.currentTemperature = (static_cast<int>(serialRxBuf[27]) - 50) / 2;
+  state.errorCode = serialRxBuf[31];
+
+  ESP_LOGI(TAG,
+    "Parsed -> Power:%s Mode:%u Fan:%u Target:%u CurrentH:%u Temp:%d Err:%u",
+    state.powerOn ? "ON" : "OFF",
+    state.mode, state.fanSpeed,
+    state.humiditySetpoint, state.currentHumidity,
+    state.currentTemperature, state.errorCode
+  );
+
+  this->clearRxBuf();
 }
 
 climate::ClimateTraits MideaDehumComponent::traits() {
@@ -277,153 +839,6 @@ climate::ClimateTraits MideaDehumComponent::traits() {
     t.set_supported_custom_presets(custom_presets);
   }
   return t;
-}
-
-void MideaDehumComponent::parseState() {
-  // --- Basic operating parameters ---
-  state.powerOn          = (serialRxBuf[11] & 0x01) != 0;
-  state.mode              = serialRxBuf[12] & 0x0F;
-  state.fanSpeed          = serialRxBuf[13] & 0x7F;
-  state.humiditySetpoint  = (serialRxBuf[17] > 100) ? 99 : serialRxBuf[17];
-
-  // --- Panel light / brightness class (bits 7–6) ---
-#ifdef USE_MIDEA_DEHUM_LIGHT
-  uint8_t new_light_class = (serialRxBuf[19] & 0xC0) >> 6;
-  if (new_light_class != this->light_class_) {
-    this->light_class_ = new_light_class;
-    if (this->light_select_) {
-      const char* light_str =
-        new_light_class == 0 ? "Auto" :
-        new_light_class == 1 ? "Off" :
-        new_light_class == 2 ? "Low" : "High";
-      this->light_select_->publish_state(light_str);
-    }
-  }
-#endif
-
-  // --- Ionizer (bit 6) ---
-#ifdef USE_MIDEA_DEHUM_ION
-  bool new_ion_state = (serialRxBuf[19] & 0x40) != 0;
-  if (new_ion_state != this->ion_state_) {
-    this->ion_state_ = new_ion_state;
-    if (this->ion_switch_) this->ion_switch_->publish_state(new_ion_state);
-  }
-#endif
-
-  // --- Sleep mode (bit 5) ---
-#ifdef USE_MIDEA_DEHUM_SLEEP
-  bool new_sleep_state = (serialRxBuf[19] & 0x20) != 0;
-  if (new_sleep_state != this->sleep_state_) {
-    this->sleep_state_ = new_sleep_state;
-    if (this->sleep_switch_) this->sleep_switch_->publish_state(new_sleep_state);
-  }
-#endif
-
-  // --- Optional: Pump bits (3–4) ---
-#ifdef USE_MIDEA_DEHUM_PUMP
-  bool new_pump_state = (serialRxBuf[19] & 0x08) != 0;
-  bool new_pump_flag  = (serialRxBuf[19] & 0x10) != 0;
-  if (new_pump_state != this->pump_state_) {
-    this->pump_state_ = new_pump_state;
-    if (this->pump_switch_) this->pump_switch_->publish_state(new_pump_state);
-  }
-  this->pump_flag_ = new_pump_flag;
-#endif
-
-  // --- Vertical swing (byte 20, bit 5) ---
-#ifdef USE_MIDEA_DEHUM_SWING
-  bool new_swing_state = (serialRxBuf[20] & 0x20) != 0;
-  if (new_swing_state != this->swing_state_) {
-    this->swing_state_ = new_swing_state;
-    if (this->swing_switch_) this->swing_switch_->publish_state(new_swing_state);
-  }
-#endif
-
-  // --- Environmental readings ---
-  state.currentHumidity = serialRxBuf[26];
-  state.currentTemperature = (static_cast<int>(serialRxBuf[27]) - 50) / 2;
-  state.errorCode = serialRxBuf[31];
-
-  ESP_LOGI(TAG,
-    "Parsed -> Power:%s Mode:%u Fan:%u Target:%u CurrentH:%u Temp:%d Err:%u",
-    state.powerOn ? "ON" : "OFF",
-    state.mode, state.fanSpeed,
-    state.humiditySetpoint, state.currentHumidity,
-    state.currentTemperature, state.errorCode
-  );
-
-  this->clearRxBuf();
-}
-
-void MideaDehumComponent::clearRxBuf() { memset(serialRxBuf, 0, sizeof(serialRxBuf)); }
-void MideaDehumComponent::clearTxBuf() { memset(serialTxBuf, 0, sizeof(serialTxBuf)); }
-
-void MideaDehumComponent::handleUart() {
-  if (!this->uart_) return;
-
-  static size_t rx_len = 0;
-
-  while (this->uart_->available()) {
-    uint8_t uint8_t_in;
-    if (!this->uart_->read_byte(&uint8_t_in)) break;
-
-    if (rx_len < sizeof(serialRxBuf)) serialRxBuf[rx_len++] = uint8_t_in;
-    else rx_len = 0;
-
-    if (rx_len == 1 && serialRxBuf[0] != 0xAA) { rx_len = 0; continue; }
-
-    if (rx_len >= 2) {
-      const uint8_t expected_len = serialRxBuf[1];
-      if (rx_len >= expected_len) {
-        std::string hex_str;
-        hex_str.reserve(expected_len * 3);
-        for (size_t i = 0; i < rx_len; i++) {
-          char buf[4];
-          snprintf(buf, sizeof(buf), "%02X ", serialRxBuf[i]);
-          hex_str += buf;
-        }
-        ESP_LOGI(TAG, "RX packet (%u uint8_ts): %s", (unsigned)rx_len, hex_str.c_str());
-
-        if (serialRxBuf[10] == 0xC8) {
-          this->parseState();
-          this->publishState();
-        } else if (serialRxBuf[10] == 0x63) {
-          this->updateAndSendNetworkStatus();
-        } else if (
-          serialRxBuf[0] == 0xAA &&
-          serialRxBuf[1] == 0x1E &&
-          serialRxBuf[2] == 0xA1 &&
-          serialRxBuf[9] == 0x64 &&
-          serialRxBuf[11] == 0x01 &&
-          serialRxBuf[15] == 0x01
-        ) {
-          App.scheduler.set_timeout(this, "factory_reset", 500, [this]() {
-            ESP_LOGW(TAG, "Performing factory reset...");
-            global_preferences->reset();
-
-            App.scheduler.set_timeout(this, "reboot_after_reset", 300, []() {
-              App.safe_reboot();
-            });
-          });
-        }
-
-        rx_len = 0;
-      }
-    }
-  }
-}
-
-void MideaDehumComponent::writeHeader(uint8_t msgType, uint8_t agreementVersion, uint8_t packetLength) {
-  currentHeader[0] = 0xAA;
-  currentHeader[1] = 10 + packetLength + 1;
-  currentHeader[2] = 0xA1;
-  currentHeader[3] = 0x00;
-  currentHeader[4] = 0x00;
-  currentHeader[5] = 0x00;
-  currentHeader[6] = 0x00;
-  currentHeader[7] = 0x00;
-  currentHeader[8] = agreementVersion;
-  currentHeader[9] = msgType;
 }
 
 void MideaDehumComponent::handleStateUpdateRequest(std::string requestedState, uint8_t mode, uint8_t fanSpeed, uint8_t humiditySetpoint) {
@@ -466,13 +881,86 @@ void MideaDehumComponent::sendSetStatus() {
   if (mode < 1 || mode > 4) mode = 3;
   setStatusCommand[2] = mode & 0x0F;
 
-  // --- Fan speed (byte 13) ---
+  // --- Fan speed (byte 3) ---
   setStatusCommand[3] = (uint8_t)state.fanSpeed;
 
-  // --- Target humidity (byte 17) ---
+#ifdef USE_MIDEA_DEHUM_TIMER
+  // Always start from the cached device view
+  uint8_t on_raw  = this->last_on_raw_;
+  uint8_t off_raw = this->last_off_raw_;
+  uint8_t ext_raw = this->last_ext_raw_;
+
+  bool force_timer_apply = false;  // set true when user changed the timer (incl. clearing)
+
+  if (this->timer_write_pending_) {
+    force_timer_apply = true;
+
+    if (this->pending_timer_hours_ <= 0.01f) {
+      // User cleared: disable both timers explicitly
+      on_raw = off_raw = ext_raw = 0x00;
+      ESP_LOGI("midea_dehum_timer", "User cleared timer -> disabling all timer bytes");
+    } else {
+      // Encode the new timer (ON when device is OFF, OFF when device is ON)
+      uint16_t total_minutes = static_cast<uint16_t>(this->pending_timer_hours_ * 60.0f + 0.5f);
+      uint8_t hours   = total_minutes / 60;
+      uint8_t minutes = total_minutes % 60;
+
+      if (minutes == 0 && hours > 0) { minutes = 60; hours--; }
+
+      uint8_t minutesH = minutes / 15;
+      uint8_t minutesL = 15 - (minutes % 15);
+      if (minutes % 15 == 0) { minutesL = 0; if (minutesH > 0) minutesH--; }
+
+      if (this->pending_applies_to_on_) {
+        on_raw  = 0x80 | ((hours & 0x1F) << 2) | (minutesH & 0x03);
+        ext_raw = (minutesL & 0x0F) << 4;
+        off_raw = 0x00;
+      } else {
+        off_raw = 0x80 | ((hours & 0x1F) << 2) | (minutesH & 0x03);
+        ext_raw = (minutesL & 0x0F);
+        on_raw  = 0x00;
+      }
+
+      ESP_LOGI("midea_dehum_timer",
+               "Updated cached timer -> %.2f h (applies to %s timer) [%02X %02X %02X]",
+               this->pending_timer_hours_,
+               this->pending_applies_to_on_ ? "ON" : "OFF", on_raw, off_raw, ext_raw);
+    }
+
+    // Update cache so future frames mirror device state
+    this->last_on_raw_  = on_raw;
+    this->last_off_raw_ = off_raw;
+    this->last_ext_raw_ = ext_raw;
+    this->timer_write_pending_ = false;
+  }
+
+  // Put timer bytes in the payload every time (device expects them)
+  setStatusCommand[4] = on_raw;
+  setStatusCommand[5] = off_raw;
+  setStatusCommand[6] = ext_raw;
+
+  // ---- timerSet flag (bit7 of our byte[3] = fanSpeed field) ----
+  // If a timer is active OR we are actively updating timer (even to 0), set the bit for THIS frame.
+  if (force_timer_apply || (on_raw & 0x80) || (off_raw & 0x80)) {
+    setStatusCommand[3] |= 0x80;
+#ifdef USE_MIDEA_DEHUM_TIMERMODE_HINT
+    // Optional: also nudge timerMode bit in byte[1] for this frame
+    setStatusCommand[1] |= 0x10;
+#endif
+  } else {
+    setStatusCommand[3] &= static_cast<uint8_t>(~0x80);
+  }
+
+  ESP_LOGD("midea_dehum_timer",
+           "Including timer bytes -> payload[4..6]=%02X %02X %02X (timerSet=%s)",
+           setStatusCommand[4], setStatusCommand[5], setStatusCommand[6],
+           (setStatusCommand[3] & 0x80) ? "1" : "0");
+#endif
+
+  // --- Target humidity (byte 7) ---
   setStatusCommand[7] = state.humiditySetpoint;
 
-  // --- Misc feature flags (byte 19) ---
+  // --- Misc feature flags (byte 9) ---
   uint8_t b9 = 0;
 
 #ifdef USE_MIDEA_DEHUM_LIGHT
@@ -486,8 +974,11 @@ void MideaDehumComponent::sendSetStatus() {
   if (this->sleep_state_) b9 |= 0x20;  // bit5 = sleep
 #endif
 #ifdef USE_MIDEA_DEHUM_PUMP
-  if (this->pump_state_) b9 |= 0x08;   // bit3 = pump enable
-  if (this->pump_flag_)  b9 |= 0x10;   // bit4 = pump disable flag
+  if (this->pump_state_) {
+    b9 |= 0x18;  // bit4 (flag) + bit3 (on)
+  } else {
+    b9 |= 0x10;  // bit4 = pump control active, bit3 = off
+  }
 #endif
 
   setStatusCommand[9] = b9;
@@ -500,50 +991,59 @@ void MideaDehumComponent::sendSetStatus() {
 #endif
 
   // --- Send assembled frame ---
-  this->sendMessage(0x02, 0x03, 25, setStatusCommand);
+  this->sendMessage(0x02, 0x03, 0x00, 25, setStatusCommand);
 }
 
-void MideaDehumComponent::updateAndSendNetworkStatus() {
+void MideaDehumComponent::updateAndSendNetworkStatus(bool connected) {
   memset(networkStatus, 0, sizeof(networkStatus));
+  if(connected) {
+    // Byte 0: module type (Wi-Fi)
+    networkStatus[0] = 0x01;
 
-  // Byte 0: module type (Wi-Fi)
-  networkStatus[0] = 0x01;
+    // Byte 1: Wi-Fi mode
+    networkStatus[1] = 0x01;
 
-  // Byte 1: Wi-Fi mode
-  networkStatus[1] = 0x01;
+    networkStatus[2] = 0x04;
 
-  networkStatus[2] = 0x04;
+    networkStatus[3] = 0x01;
+    networkStatus[4] = 0x00;
+    networkStatus[5] = 0x00;
+    networkStatus[6] = 0x7F;
 
-  networkStatus[3] = 1;
-  networkStatus[4] = 0;
-  networkStatus[5] = 0;
-  networkStatus[6] = 127;
+    // Byte 7: RF signal (not used)
+    networkStatus[7] = 0xFF;
 
-  // Byte 7: RF signal (not used)
-  networkStatus[7] = 0xFF;
+    // Byte 8: router status
+    networkStatus[8] = 0x00;
 
-  // Byte 8: router status
-  networkStatus[8] = 0x00;
+    // Byte 9: cloud
+    networkStatus[9] = 0x00;
 
-  // Byte 9: cloud
-  networkStatus[9] = 0x00;
+    // Byte 10: Direct LAN connection (not applicable)
+    networkStatus[10] = 0x00;
 
-  // Byte 10: Direct LAN connection (not applicable)
-  networkStatus[10] = 0x00;
+    // Byte 11: TCP connection count (not used)
+    networkStatus[11] = 0x00;
 
-  // Byte 11: TCP connection count (not used)
-  networkStatus[11] = 0x00;
+    networkStatus[12] = 0x01;
+  }
+  else {
+    networkStatus[0] = 0x01;
+    networkStatus[1] = 0x01;
+    networkStatus[7] = 0xFF;
+    networkStatus[8] = 0x02;
+  }
 
-  this->sendMessage(0x0D, 0x03, 20, networkStatus);
+  this->sendMessage(0x0D, 0x03, 0xBF, sizeof(networkStatus), networkStatus);
 }
 
 void MideaDehumComponent::getStatus() {
-  this->sendMessage(0x03, 0x03, 21, getStatusCommand);
+  this->sendMessage(0x03, 0x03, 0x00, 21, getStatusCommand);
 }
 
-void MideaDehumComponent::sendMessage(uint8_t msgType, uint8_t agreementVersion, uint8_t payloadLength, uint8_t *payload) {
+void MideaDehumComponent::sendMessage(uint8_t msgType, uint8_t agreementVersion, uint8_t frameSyncCheck, uint8_t payloadLength, uint8_t *payload) {
   this->clearTxBuf();
-  this->writeHeader(msgType, agreementVersion, payloadLength);
+  this->writeHeader(msgType, agreementVersion, frameSyncCheck, payloadLength);
   memcpy(serialTxBuf, currentHeader, 10);
   memcpy(serialTxBuf + 10, payload, payloadLength);
   serialTxBuf[10 + payloadLength]     = crc8(serialTxBuf + 10, payloadLength);

--- a/components/midea_dehum/midea_dehum.h
+++ b/components/midea_dehum/midea_dehum.h
@@ -7,27 +7,33 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/climate/climate.h"
 #ifdef USE_MIDEA_DEHUM_BINARY_SENSOR
-  #include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #endif
 #ifdef USE_MIDEA_DEHUM_SENSOR
-  #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/sensor/sensor.h"
 #endif
 #ifdef USE_MIDEA_DEHUM_SWITCH
-  #include "esphome/components/switch/switch.h"
+#include "esphome/components/switch/switch.h"
+#endif
+#ifdef USE_MIDEA_DEHUM_SELECT
+#include "esphome/components/select/select.h"
+#endif
+#ifdef USE_MIDEA_DEHUM_NUMBER
+#include "esphome/components/number/number.h"
 #endif
 
 namespace esphome {
 namespace midea_dehum {
 
-// ─────────────── Forward declarations ───────────────
-#ifdef USE_MIDEA_DEHUM_SWITCH
 class MideaDehumComponent;
-#endif
 #ifdef USE_MIDEA_DEHUM_ION
 class MideaIonSwitch;
 #endif
 #ifdef USE_MIDEA_DEHUM_SWING
 class MideaSwingSwitch;
+#endif
+#ifdef USE_MIDEA_DEHUM_PUMP
+class MideaPumpSwitch;
 #endif
 #ifdef USE_MIDEA_DEHUM_BEEP
 class MideaBeepSwitch;
@@ -36,7 +42,6 @@ class MideaBeepSwitch;
 class MideaSleepSwitch;
 #endif
 
-// ─────────────── Switch subclasses ───────────────
 #ifdef USE_MIDEA_DEHUM_ION
 class MideaIonSwitch : public switch_::Switch, public Component {
  public:
@@ -53,6 +58,16 @@ class MideaSwingSwitch : public switch_::Switch, public Component {
  public:
   void set_parent(MideaDehumComponent *parent) { this->parent_ = parent; }
 
+ protected:
+  void write_state(bool state) override;
+  MideaDehumComponent *parent_{nullptr};
+};
+#endif
+
+#ifdef USE_MIDEA_DEHUM_PUMP
+class MideaPumpSwitch : public esphome::switch_::Switch {
+ public:
+  void set_parent(MideaDehumComponent *parent) { this->parent_ = parent; }
  protected:
   void write_state(bool state) override;
   MideaDehumComponent *parent_{nullptr};
@@ -81,6 +96,28 @@ class MideaSleepSwitch : public switch_::Switch, public Component {
 };
 #endif
 
+#ifdef USE_MIDEA_DEHUM_CAPABILITIES
+class MideaCapabilitiesSelect : public select::Select, public Component {
+ public:
+  void set_parent(class MideaDehumComponent *parent) { this->parent_ = parent; }
+
+ protected:
+  void control(const std::string &value) override {}
+  class MideaDehumComponent *parent_{nullptr};
+};
+#endif
+
+#ifdef USE_MIDEA_DEHUM_TIMER
+class MideaTimerNumber : public number::Number, public Component {
+ public:
+  void set_parent(class MideaDehumComponent *parent) { this->parent_ = parent; }
+
+ protected:
+  void control(float value) override;
+  class MideaDehumComponent *parent_{nullptr};
+};
+#endif
+
 // ─────────────── Main component ───────────────
 class MideaDehumComponent : public climate::Climate,
                             public uart::UARTDevice,
@@ -97,13 +134,20 @@ class MideaDehumComponent : public climate::Climate,
 #endif
 #ifdef USE_MIDEA_DEHUM_ION
   void set_ion_switch(MideaIonSwitch *s);
-  void set_ion_state(bool on);
+  void set_ion_state(bool on, bool from_device);
   bool get_ion_state() const { return this->ion_state_; }
 #endif
 #ifdef USE_MIDEA_DEHUM_SWING
   void set_swing_switch(MideaSwingSwitch *s);
-  void set_swing_state(bool on);
+  void set_swing_state(bool on, bool from_device);
   bool get_swing_state() const { return this->swing_state_; }
+#endif
+#ifdef USE_MIDEA_DEHUM_PUMP
+  MideaPumpSwitch *pump_switch_{nullptr};
+  bool pump_state_{false};
+
+  void set_pump_switch(MideaPumpSwitch *s);
+  void set_pump_state(bool on, bool from_device);
 #endif
 #ifdef USE_MIDEA_DEHUM_BEEP
   MideaBeepSwitch *beep_switch_{nullptr};
@@ -116,11 +160,20 @@ class MideaDehumComponent : public climate::Climate,
   MideaSleepSwitch *sleep_switch_{nullptr};
   bool sleep_state_{false};
   void set_sleep_switch(MideaSleepSwitch *s);
-  void set_sleep_state(bool on);
-  void restore_sleep_state();
+  void set_sleep_state(bool on, bool from_device);
+#endif
+#ifdef USE_MIDEA_DEHUM_CAPABILITIES
+  MideaCapabilitiesSelect *capabilities_select_{nullptr};
+  void set_capabilities_select(MideaCapabilitiesSelect *s) { this->capabilities_select_ = s; }
+  void update_capabilities_select(const std::vector<std::string> &options);
+  void getDeviceCapabilities();
+  void getDeviceCapabilitiesMore();
+#endif
+#ifdef USE_MIDEA_DEHUM_TIMER
+  void set_timer_number(MideaTimerNumber *n);
+  void set_timer_hours(float hours, bool from_device);
 #endif
 
-  // Display mode names
   std::string display_mode_setpoint_{"Setpoint"};
   std::string display_mode_continuous_{"Continuous"};
   std::string display_mode_smart_{"Smart"};
@@ -145,10 +198,11 @@ class MideaDehumComponent : public climate::Climate,
                                 uint8_t mode,
                                 uint8_t fan_speed,
                                 uint8_t humidity_setpoint);
-  void updateAndSendNetworkStatus();
+  void updateAndSendNetworkStatus(bool connected);
   void getStatus();
   void sendMessage(uint8_t msg_type,
                    uint8_t agreement_version,
+                   uint8_t frame_SyncCheck,
                    uint8_t payload_length,
                    uint8_t *payload);
 
@@ -157,7 +211,30 @@ class MideaDehumComponent : public climate::Climate,
   void clearTxBuf();
   void writeHeader(uint8_t msg_type,
                    uint8_t agreement_version,
+                   uint8_t frame_SyncCheck,
                    uint8_t packet_length);
+  void performHandshakeStep();
+  uint8_t handshake_step_{0};
+  bool handshake_done_{false};
+
+  enum BusState {
+    BUS_IDLE,
+    BUS_RECEIVING,
+    BUS_SENDING
+  };
+
+  BusState bus_state_ = BUS_IDLE;
+  uint32_t last_rx_time_ = 0;
+  bool tx_pending_ = false;
+  std::vector<uint8_t> tx_buffer_;
+
+  void queueTx(const uint8_t *data, size_t len);
+  void sendQueuedPacket();
+  void processPacket(uint8_t *data, size_t len);
+
+  uint8_t appliance_type_ = 0x00;
+  uint8_t protocol_version_ = 0x00;
+  bool device_info_known_ = false;
 
   uart::UARTComponent *uart_{nullptr};
   uint32_t status_poll_interval_{30000};
@@ -175,6 +252,21 @@ class MideaDehumComponent : public climate::Climate,
 #ifdef USE_MIDEA_DEHUM_SWING
   MideaSwingSwitch *swing_switch_{nullptr};
   bool swing_state_{false};
+#endif
+#ifdef USE_MIDEA_DEHUM_TIMER
+  MideaTimerNumber *timer_number_{nullptr};
+  float last_timer_hours_{0.0f};
+
+  uint8_t last_on_raw_{0};
+  uint8_t last_off_raw_{0};
+  uint8_t last_ext_raw_{0};
+
+  bool timer_write_pending_{false};
+  float pending_timer_hours_{0.0f};
+  bool pending_applies_to_on_{false};
+  uint8_t timer_on_raw_{0};
+  uint8_t timer_off_raw_{0};
+  uint8_t timer_ext_raw_{0};
 #endif
 };
 

--- a/components/midea_dehum/number.py
+++ b/components/midea_dehum/number.py
@@ -1,0 +1,34 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import number
+from esphome.const import CONF_ID, UNIT_HOUR, ICON_TIMER
+from . import midea_dehum_ns, CONF_MIDEA_DEHUM_ID
+
+cg.add_define("USE_MIDEA_DEHUM_NUMBER")
+
+MideaDehum = midea_dehum_ns.class_("MideaDehumComponent", cg.Component)
+MideaTimerNumber = midea_dehum_ns.class_("MideaTimerNumber", number.Number, cg.Component)
+
+CONF_TIMER = "timer"
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.Required(CONF_MIDEA_DEHUM_ID): cv.use_id(MideaDehum),
+    cv.Optional(CONF_TIMER): number.number_schema(
+        MideaTimerNumber,
+        unit_of_measurement=UNIT_HOUR,
+        icon=ICON_TIMER,
+    ),
+})
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_MIDEA_DEHUM_ID])
+
+    if CONF_TIMER in config:
+        cg.add_define("USE_MIDEA_DEHUM_TIMER")
+        n = await number.new_number(
+            config[CONF_TIMER],
+            min_value=0,
+            max_value=24.0,
+            step=0.5,
+        )
+        cg.add(parent.set_timer_number(n))

--- a/components/midea_dehum/select.py
+++ b/components/midea_dehum/select.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import select
+from . import midea_dehum_ns, CONF_MIDEA_DEHUM_ID
+
+cg.add_define("USE_MIDEA_DEHUM_SELECT")
+
+MideaCapabilitiesSelect = midea_dehum_ns.class_("MideaCapabilitiesSelect", select.Select, cg.Component)
+MideaDehum = midea_dehum_ns.class_("MideaDehumComponent", cg.Component)
+
+CONF_CAPABILITIES = "capabilities"
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.Required(CONF_MIDEA_DEHUM_ID): cv.use_id(MideaDehum),
+    cv.Optional(CONF_CAPABILITIES): select.select_schema(
+        MideaCapabilitiesSelect,
+        icon="mdi:chip"
+    ),
+})
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_MIDEA_DEHUM_ID])
+
+    if CONF_CAPABILITIES in config:
+        cg.add_define("USE_MIDEA_DEHUM_CAPABILITIES")
+        s = await select.new_select(
+            config[CONF_CAPABILITIES],
+            options=[],
+        )
+        cg.add(parent.set_capabilities_select(s))

--- a/components/midea_dehum/switch.py
+++ b/components/midea_dehum/switch.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch
-from esphome.const import CONF_ID
 from . import midea_dehum_ns, CONF_MIDEA_DEHUM_ID
 
 cg.add_define("USE_MIDEA_DEHUM_SWITCH")
@@ -10,12 +9,14 @@ MideaIonSwitch = midea_dehum_ns.class_("MideaIonSwitch", switch.Switch, cg.Compo
 MideaSwingSwitch = midea_dehum_ns.class_("MideaSwingSwitch", switch.Switch, cg.Component)
 MideaBeepSwitch = midea_dehum_ns.class_("MideaBeepSwitch", switch.Switch, cg.Component)
 MideaSleepSwitch = midea_dehum_ns.class_("MideaSleepSwitch", switch.Switch, cg.Component)
+MideaPumpSwitch = midea_dehum_ns.class_("MideaPumpSwitch", switch.Switch, cg.Component)
 MideaDehum = midea_dehum_ns.class_("MideaDehumComponent", cg.Component)
 
 CONF_IONIZER = "ionizer"
 CONF_SWING = "swing"
 CONF_BEEP = "beep"
 CONF_SLEEP = "sleep"
+CONF_PUMP = "pump"
 
 CONFIG_SCHEMA = cv.Schema({
     cv.Required(CONF_MIDEA_DEHUM_ID): cv.use_id(MideaDehum),
@@ -23,6 +24,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_SWING): switch.switch_schema(MideaSwingSwitch, icon="mdi:arrow-oscillating"),
     cv.Optional(CONF_BEEP): switch.switch_schema(MideaBeepSwitch, icon="mdi:volume-high"),
     cv.Optional(CONF_SLEEP): switch.switch_schema(MideaSleepSwitch, icon="mdi:sleep"),
+    cv.Optional(CONF_PUMP): switch.switch_schema(MideaPumpSwitch, icon="mdi:water-pump"),
 })
 
 async def to_code(config):
@@ -38,6 +40,11 @@ async def to_code(config):
         sw = await switch.new_switch(config[CONF_SWING])
         cg.add(parent.set_swing_switch(sw))
 
+    if CONF_PUMP in config:
+        cg.add_define("USE_MIDEA_DEHUM_PUMP")
+        sw = await switch.new_switch(config[CONF_PUMP])
+        cg.add(parent.set_pump_switch(sw))
+
     if CONF_BEEP in config:
         cg.add_define("USE_MIDEA_DEHUM_BEEP")
         sw = await switch.new_switch(config[CONF_BEEP])
@@ -45,5 +52,5 @@ async def to_code(config):
 
     if CONF_SLEEP in config:
         cg.add_define("USE_MIDEA_DEHUM_SLEEP")
-        s = await switch.new_switch(config[CONF_SLEEP])
-        cg.add(parent.set_sleep_switch(s))
+        sw = await switch.new_switch(config[CONF_SLEEP])
+        cg.add(parent.set_sleep_switch(sw))


### PR DESCRIPTION
🆕 Internal Device Timer Support (optional)

Adds a number entity to control the built-in ON/OFF timer directly from Home Assistant.

Synchronizes timer values with the dehumidifier and updates automatically from device reports.

🤝 Improved UART Handshake Process

Enhanced initialization reliability.

⚙️ Background & Code Improvements

Refactored UART processing and frame validation logic.

Added better buffer handling, logging, and device status synchronization.

Improved modular structure and optional-entity compilation.